### PR TITLE
Fix detection of parameter annotations where there are multiple unknown ...

### DIFF
--- a/core-server/src/main/java/org/glassfish/jersey/server/model/Parameter.java
+++ b/core-server/src/main/java/org/glassfish/jersey/server/model/Parameter.java
@@ -313,8 +313,8 @@ public class Parameter implements AnnotatedElement {
             } else if (DefaultValue.class == annotation.annotationType()) {
                 paramDefault = ((DefaultValue) annotation).value();
             } else {
-                // lets only clear things down if we've not found a ANNOTATION_HELPER_MAP annotation already
-                if (paramAnnotation == null) {
+                // Take latest unknown annotation, but don't override known annotation
+                if ((paramAnnotation == null) || (paramSource == Source.UNKNOWN)) {
                     paramAnnotation = annotation;
                     paramSource = Source.UNKNOWN;
                     paramName = getValue(annotation);

--- a/core-server/src/test/java/org/glassfish/jersey/server/model/ParameterWithMultipleAnnotationsTest.java
+++ b/core-server/src/test/java/org/glassfish/jersey/server/model/ParameterWithMultipleAnnotationsTest.java
@@ -51,29 +51,44 @@ import static org.junit.Assert.assertEquals;
  * Checks that Parameters work fine with multiple annotations
  */
 public class ParameterWithMultipleAnnotationsTest {
-
+    
     @Test
-    public void testParametersWithMultiple() throws NoSuchMethodException {
+    public void testParametersWithMultiple() throws Exception {
+        checkMyResourceMethod("processTrailingUnknown");
+        checkMyResourceMethod("processLeadingUnknown");
+        checkMyResourceMethod("processLeadingAndTrailingUnknown");
+        checkMyResourceMethod("processSingleUnknown");
+        checkMyResourceMethod("processDoubleUnknown");
+    }
+    
+    private void checkMyResourceMethod(String methodName) throws Exception {
         Class<?> declaring = MyResource.class;
-        Method method = declaring.getMethod("process", String.class);
+        Method method = declaring.getMethod(methodName, String.class);
         final List<Parameter> parameters = Parameter.create(declaring, declaring, method, false);
         assertEquals(1, parameters.size());
         Parameter parameter = parameters.get(0);
-        assertEquals(String.class, parameter.getRawType());
-        assertEquals(String.class, parameter.getType());
-        assertEquals("id", parameter.getSourceName());
+        assertEquals(methodName, String.class, parameter.getRawType());
+        assertEquals(methodName, String.class, parameter.getType());
+        assertEquals(methodName, "correct", parameter.getSourceName());
     }
-
-    private static class MyResource {
-        public void process(@PathParam("id") @DummyAnnotation String id) {
-
-        }
+    
+    @java.lang.annotation.Target({java.lang.annotation.ElementType.PARAMETER, java.lang.annotation.ElementType.METHOD, java.lang.annotation.ElementType.FIELD})
+    @java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy.RUNTIME)
+    public @interface LeadAnnotation {
+        String value() default "lead";
     }
 
     @java.lang.annotation.Target({java.lang.annotation.ElementType.PARAMETER, java.lang.annotation.ElementType.METHOD, java.lang.annotation.ElementType.FIELD})
     @java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy.RUNTIME)
-    public @interface DummyAnnotation {
+    public @interface TrailAnnotation {
+        String value() default "trail";
+    }
+
+    private static class MyResource {
+        public void processTrailingUnknown(@PathParam("correct") @TrailAnnotation String id) {}
+        public void processLeadingUnknown(@LeadAnnotation @PathParam("correct") String id) {}
+        public void processLeadingAndTrailingUnknown(@LeadAnnotation @PathParam("correct") @TrailAnnotation String id) {}
+        public void processSingleUnknown(@LeadAnnotation("correct") String id) {}
+        public void processDoubleUnknown(@LeadAnnotation @TrailAnnotation("correct") String id) {}
     }
 }
-
-


### PR DESCRIPTION
...annotations (and no known annotations) to choose the last annotation.

Updated unit test for parameter annotation discovery to cover all combinations of known/unknown annotations.

Fixes regression introduced in r5760/JERSEY-1352
