### PR TITLE
Fixed Apache Connector test case that was throwing an exception when using the default BasicClientConnManager, which is not recommended for a multi-threaded client requests.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -930,7 +930,7 @@
             <dependency>
                 <groupId>org.apache.httpcomponents</groupId>
                 <artifactId>httpclient</artifactId>
-                <version>4.2.3</version>
+                <version>${httpclient.version}</version>
             </dependency>
 
             <dependency>
@@ -1177,6 +1177,7 @@
         <servlet2.version>2.4</servlet2.version>
         <servlet3.version>3.1.0</servlet3.version>
         <simple.version>5.0.4</simple.version>
+        <httpclient.version>4.2.5</httpclient.version>
         <validation.api.version>1.1.0.Final</validation.api.version>
         <weld.version>2.0.0.Final</weld.version>
     </properties>


### PR DESCRIPTION
Fixed Apache Connector test case that was throwing an exception when using the default BasicClientConnManager, which is not recommended for a multi-threaded client requests. 

"javax.ws.rs.ProcessingException: java.lang.IllegalStateException: Invalid use of BasicClientConnManager: connection still allocated.
Make sure to release the connection before allocating another one."

Upgraded Apache HttpClient to 4.2.5 which includes bunch of critical fixes since 4.2.3 (http://www.apache.org/dist/httpcomponents/httpclient/RELEASE_NOTES-4.2.x.txt).
