### PR TITLE
Minor update in documentation so that JSON-P is pointing to correct artifact.

### DIFF
--- a/docs/src/main/docbook/media.xml
+++ b/docs/src/main/docbook/media.xml
@@ -477,7 +477,7 @@ final Application application = new ResourceConfig()
 
                     <programlisting language="xml" linenumbering="unnumbered">&lt;dependency&gt;
     &lt;groupId&gt;org.glassfish.jersey.media&lt;/groupId&gt;
-    &lt;artifactId&gt;jersey-media-processing&lt;/artifactId&gt;
+    &lt;artifactId&gt;jersey-media-json-processing&lt;/artifactId&gt;
     &lt;version&gt;&version;&lt;/version&gt;
 &lt;/dependency&gt;</programlisting>
 


### PR DESCRIPTION
The artifactId was pointing to non-existent artifact 'jersey-media-processing' while it should be 'jersey-media-json-processing'.
