### PR TITLE
Support "application/x-www-form-urlencoded; UTF-8" content type

### DIFF
--- a/core-server/src/main/java/org/glassfish/jersey/server/internal/inject/FormParamValueFactoryProvider.java
+++ b/core-server/src/main/java/org/glassfish/jersey/server/internal/inject/FormParamValueFactoryProvider.java
@@ -191,7 +191,7 @@ final class FormParamValueFactoryProvider extends AbstractValueFactoryProvider {
         }
 
         private Form getFormParameters(ContainerRequest requestContext) {
-            if (requestContext.getMediaType().equals(MediaType.APPLICATION_FORM_URLENCODED_TYPE)) {
+            if (MediaTypes.typeEqual(MediaType.APPLICATION_FORM_URLENCODED_TYPE, requestContext.getMediaType())) {
                 requestContext.bufferEntity();
                 Form form;
                 if (decode) {


### PR DESCRIPTION
Form parameters (@FormParam) are empty when request is made with "application/x-www-form-urlencoded; UTF-8" content type (Firefox)
