### PR TITLE
nested jar can't find class path resource.

### DIFF
--- a/core-server/src/main/java/org/glassfish/jersey/server/internal/scanning/JarZipSchemeResourceFinderFactory.java
+++ b/core-server/src/main/java/org/glassfish/jersey/server/internal/scanning/JarZipSchemeResourceFinderFactory.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) 2012 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012-2013 Oracle and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development


### PR DESCRIPTION
When run with 'java -jar nested.jar' the application cannot find class path resource on startup.

```
java -jar nested.jar

nested.jar
  | - lib
    | - jersey-spring3-2.2.jar
      | - org.glassfish.....

java.io.FileNotFoundException: nested.jar!/lib/jersey-spring3-2.2.jar (No such file or directory)
at java.io.FileInputStream.open(Native Method)
at java.io.FileInputStream.&lt;init&gt;(FileInputStream.java:138)
at java.io.FileInputStream.&lt;init&gt;(FileInputStream.java:97)
at sun.net.www.protocol.file.FileURLConnection.connect(FileURLConnection.java:90)
at sun.net.www.protocol.file.FileURLConnection.getInputStream(FileURLConnection.java:188)
at java.net.URL.openStream(URL.java:1037)
at org.glassfish.jersey.server.internal.scanning.JarZipSchemeResourceFinderFactory.getInputStream(JarZipSchemeResourceFinderFactory.java:173)
at org.glassfish.jersey.server.internal.scanning.JarZipSchemeResourceFinderFactory.create(JarZipSchemeResourceFinderFactory.java:84)
at org.glassfish.jersey.server.internal.scanning.JarZipSchemeResourceFinderFactory.create(JarZipSchemeResourceFinderFactory.java:64)
at org.glassfish.jersey.server.internal.scanning.PackageNamesScanner.addResourceFinder(PackageNamesScanner.java:280)
at org.glassfish.jersey.server.internal.scanning.PackageNamesScanner.init(PackageNamesScanner.java:196)
at org.glassfish.jersey.server.internal.scanning.PackageNamesScanner.&lt;init&gt;(PackageNamesScanner.java:153)
at org.glassfish.jersey.server.internal.scanning.PackageNamesScanner.&lt;init&gt;(PackageNamesScanner.java:110)
at org.glassfish.jersey.server.ResourceConfig.packages(ResourceConfig.java:665)
```

That happens because JarZipSchemeResourceFinderFactory is  one time split(last index only).
