### PR TITLE
Adds handling of HttpOnly when converting NewCookie to string suitable for HTTP Set-Cookie header

### DIFF
--- a/core-common/src/main/java/org/glassfish/jersey/message/internal/NewCookieProvider.java
+++ b/core-common/src/main/java/org/glassfish/jersey/message/internal/NewCookieProvider.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) 2010-2012 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010-2013 Oracle and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development


### PR DESCRIPTION
Currently, the httpOnly boolean in NewCookie is not honoured when creating the string representation for the cookie (as far as I can tell, toString() is used when setting the Set-Cookie HTTP header). The effect is that it is not possible to set cookies to HttpOnly in Jersey. This diff changes that.
