### PR TITLE
Logging mappable exception can be disabled

### DIFF
--- a/core-server/src/main/java/org/glassfish/jersey/server/ServerProperties.java
+++ b/core-server/src/main/java/org/glassfish/jersey/server/ServerProperties.java
@@ -191,6 +191,23 @@ public final class ServerProperties {
     public static final String LANGUAGE_MAPPINGS = "jersey.config.server.languageMappings";
 
     /**
+     * If the property is set to {@code true} then exceptions which are instance of MappableException or
+     * WebApplicationException will not be log by the server
+     *
+     * <p>
+     * The property value MUST be an instance of {@code Boolean} type or a {@code String} convertible
+     * to {@code Boolean} type.
+     * </p>
+     * <p>
+     * A default value is {@code false}.
+     * </p>
+     * <p>
+     * The name of the configuration property is <tt>{@value}</tt>.
+     * </p>
+     */
+    public static final String LOGGING_MAPPABLE_EXCEPTION_DISABLE = "jersey.config.server.logging.mappableException.disable";
+
+    /**
      * Defines configuration of HTTP method overriding.
      *
      * This property is used by {@link org.glassfish.jersey.server.filter.HttpMethodOverrideFilter} to determine

--- a/core-server/src/main/java/org/glassfish/jersey/server/ServerRuntime.java
+++ b/core-server/src/main/java/org/glassfish/jersey/server/ServerRuntime.java
@@ -77,6 +77,7 @@ import javax.inject.Provider;
 import org.glassfish.jersey.internal.inject.Injections;
 import org.glassfish.jersey.internal.util.Closure;
 import org.glassfish.jersey.internal.util.Producer;
+import org.glassfish.jersey.internal.util.PropertiesHelper;
 import org.glassfish.jersey.internal.util.collection.Ref;
 import org.glassfish.jersey.internal.util.collection.Refs;
 import org.glassfish.jersey.internal.util.collection.Value;
@@ -412,6 +413,8 @@ class ServerRuntime {
             Throwable throwable = originalThrowable;
             boolean inMappable = false;
             boolean mappingNotFound = false;
+            boolean loggingMappableExceptionDisable = PropertiesHelper.getValue(runtime.configuration.getProperties(),
+                    ServerProperties.LOGGING_MAPPABLE_EXCEPTION_DISABLE, Boolean.FALSE);
 
             do {
                 if (throwable instanceof MappableException) {
@@ -430,7 +433,7 @@ class ServerRuntime {
                     }
 
                     // Log cause of WebApplicationException.
-                    if (cause != null) {
+                    if (cause != null && !loggingMappableExceptionDisable) {
                         LOGGER.log(Level.WARNING, LocalizationMessages.WEB_APPLICATION_EXCEPTION_CAUSE(), cause);
                     }
 

--- a/examples/bean-validation-webapp/src/main/java/org/glassfish/jersey/examples/beanvalidation/webapp/MyApplication.java
+++ b/examples/bean-validation-webapp/src/main/java/org/glassfish/jersey/examples/beanvalidation/webapp/MyApplication.java
@@ -55,6 +55,7 @@ import org.glassfish.jersey.examples.beanvalidation.webapp.resource.ContactCardR
 import org.glassfish.jersey.moxy.json.MoxyJsonConfig;
 import org.glassfish.jersey.moxy.json.MoxyJsonFeature;
 import org.glassfish.jersey.server.ResourceConfig;
+import org.glassfish.jersey.server.ServerProperties;
 import org.glassfish.jersey.server.validation.ValidationConfig;
 import org.glassfish.jersey.server.validation.internal.InjectingConstraintValidatorFactory;
 
@@ -75,6 +76,8 @@ public class MyApplication extends ResourceConfig {
         // Providers - JSON.
         register(MoxyJsonFeature.class);
         register(JsonConfiguration.class);
+
+        property(ServerProperties.LOGGING_MAPPABLE_EXCEPTION_DISABLE, true);
     }
 
     /**


### PR DESCRIPTION
From version 2.3 every exception that is instance of MappableException or WebApplicationException is logged. When a service handle a lot of requests and some of those requests for example do not satisfy constraint validation then we can see in logs a lot of exceptions despite the fact that the service works fine. This pull request allows disabling logging of exceptions which are instance of MappableException or WebApplicationException through setting LOGGING_MAPPABLE_EXCEPTION_DISABLE property to true. Thanks this pull request logs can look clean when service works fine.
