### PR TITLE
JERSEY-2205: Jersey client - The ClientAsyncExecutorsFactory hosts thread pools that are not shut down when the hosting client is shut down.

### DIFF
--- a/core-client/src/main/java/org/glassfish/jersey/client/ClientAsyncExecutorsFactory.java
+++ b/core-client/src/main/java/org/glassfish/jersey/client/ClientAsyncExecutorsFactory.java
@@ -96,4 +96,10 @@ class ClientAsyncExecutorsFactory extends ExecutorsFactory<ClientRequest> {
     public ExecutorService getRespondingExecutor(ClientRequest request) {
         return respondingExecutor;
     }
+
+    @Override
+    public void shutdown() {
+        requestingExecutor.shutdownNow();
+        respondingExecutor.shutdownNow();
+    }
 }

--- a/core-client/src/main/java/org/glassfish/jersey/client/ClientRuntime.java
+++ b/core-client/src/main/java/org/glassfish/jersey/client/ClientRuntime.java
@@ -249,7 +249,11 @@ class ClientRuntime {
      * Close the client runtime and release the underlying transport connector.
      */
     public void close() {
-        connector.close();
+        try {
+            connector.close();
+        } finally {
+            asyncExecutorsFactory.shutdown();
+        }
     }
 
     /**

--- a/core-common/src/main/java/org/glassfish/jersey/process/internal/ExecutorsFactory.java
+++ b/core-common/src/main/java/org/glassfish/jersey/process/internal/ExecutorsFactory.java
@@ -149,5 +149,8 @@ public abstract class ExecutorsFactory<REQUEST> {
      */
     public abstract ExecutorService getRespondingExecutor(REQUEST request);
 
-
+    /**
+     * Closes all underlying executors.
+     */
+    public abstract void shutdown();
 }

--- a/core-common/src/test/java/org/glassfish/jersey/process/internal/TestExecutorsFactory.java
+++ b/core-common/src/test/java/org/glassfish/jersey/process/internal/TestExecutorsFactory.java
@@ -110,4 +110,10 @@ public class TestExecutorsFactory extends ExecutorsFactory<String> {
             }).in(Singleton.class);
         }
     }
+
+    @Override
+    public void shutdown() {
+        requestingExecutor.shutdownNow();
+        respondingExecutor.shutdownNow();
+    }
 }

--- a/core-server/src/main/java/org/glassfish/jersey/server/ServerExecutorsFactory.java
+++ b/core-server/src/main/java/org/glassfish/jersey/server/ServerExecutorsFactory.java
@@ -100,4 +100,10 @@ class ServerExecutorsFactory extends ExecutorsFactory<ContainerRequest> {
     public ExecutorService getRespondingExecutor(ContainerRequest request) {
         return respondingExecutor;
     }
+
+    @Override
+    public void shutdown() {
+        requestingExecutor.shutdownNow();
+        respondingExecutor.shutdownNow();
+    }
 }


### PR DESCRIPTION
When a `JerseyClient` that was using asynchronous requests in the past is closed via `Client#close()` shortly before the exit point of a Java program, this program will not exit for a couple of seconds (unless `System.exit(int)` is called explicitly).

When looking at the thread dump of the application, I found that there were several alive threads named _jersey-client-async-executor-x_ which were in a waiting state even after I shut the client down. Tracing this, I found that the `ClientAsyncExecutorsFactory` is hosting two `ExecutorServices` where the `requestingExecutor` represents an actual thread pool. This thread pool is not shut down explicitly, even though the hosting `ClientRuntime` was closed. As a result, the JVM cannot exit before the threads have expired what takes up to 60 seconds. I created a small patch that closes the underlying `ExecutorService` and my application did not longer exit wit this delay.

I therefore suggest to add a method `ExecutorsFactory#shutdown()` which can be invoked by the `ClientRuntime` when the latter is closed in order to avoid this transitory thread leak. I suggest making this method a part of the `ExecutorsFactory`'s contract for consistency reasons even though it is only required for the `ClientRuntime` since the `ServerRuntime` is not explicitly shut down.

I created an [issue](https://java.net/jira/browse/JERSEY-2205) to this pull request and signed the Oracle contributor agreement. However, it is hard to provide a unit test covering this issue. It is however easy to see from the code that the executor service is never explicitly shut down in the current version. From the javadocs:

> An unused ExecutorService should be shut down to allow reclamation of its resources.

**Note**: I was not able to build the project. I got numerous test case failures even without my patch.
