### PR TITLE
JERSEY-2222: Support ClientProperties.ASYNC_THREADPOOL_SIZE

### DIFF
--- a/core-client/src/main/java/org/glassfish/jersey/client/ClientConfig.java
+++ b/core-client/src/main/java/org/glassfish/jersey/client/ClientConfig.java
@@ -377,7 +377,7 @@ public class ClientConfig implements Configurable<ClientConfig>, Configuration {
             // Bind providers.
             ProviderBinder.bindProviders(runtimeConfig.getComponentBag(), RuntimeType.CLIENT, null, locator);
 
-            final ClientRuntime crt = new ClientRuntime(configuration, connector, locator);
+            final ClientRuntime crt = new ClientRuntime(runtimeConfig, connector, locator);
             client.addListener(new JerseyClient.LifecycleListener() {
                 @Override
                 public void onClose() {

--- a/core-client/src/main/java/org/glassfish/jersey/client/ClientProperties.java
+++ b/core-client/src/main/java/org/glassfish/jersey/client/ClientProperties.java
@@ -118,7 +118,6 @@ public final class ClientProperties {
      * <p />
      * The name of the configuration property is <tt>{@value}</tt>.
      */
-    // TODO add support in default connector (ported from Jersey 1.x);
     public static final String ASYNC_THREADPOOL_SIZE = "jersey.config.client.async.threadPoolSize";
     /**
      * If {@link org.glassfish.jersey.client.filter.EncodingFilter} is


### PR DESCRIPTION
So far, the `ClientProperties.ASYNC_THREADPOOL_SIZE` property is ignored by the Jersey implementation. However, it should be considered by the `ClientAsyncExecutorsFactory` which can retreive a `CommonConfig` instance from its creating `ClientRuntime` as long as this instance is informed by its building `ClientConfig`.

In dependency of the feature, a cached thread pool or a fixed thread pool can be used.

I already filed a [Jira issue](https://java.net/jira/browse/JERSEY-2222).
