### PR TITLE
Introduce fallback to CDI.lookup() on the BeanManager lookup.

### DIFF
--- a/containers/glassfish/jersey-gf-cdi/src/main/java/org/glassfish/jersey/gf/cdi/internal/CdiComponentProvider.java
+++ b/containers/glassfish/jersey-gf-cdi/src/main/java/org/glassfish/jersey/gf/cdi/internal/CdiComponentProvider.java
@@ -443,8 +443,7 @@ public class CdiComponentProvider implements ComponentProvider, Extension {
     }
 
     private static BeanManager beanManagerFromJndi() {
-    	BeanManager beanManager=null;
-        try {
+    	try {
         	return (BeanManager)new InitialContext().lookup("java:comp/BeanManager");
         } catch (Exception ex) {
         	try {
@@ -455,7 +454,6 @@ public class CdiComponentProvider implements ComponentProvider, Extension {
             	return null;
         	}
         }
-        return beanManager;
     }
 
     private void bindHk2ClassAnalyzer() {


### PR DESCRIPTION
I introduced a fallback to the standard CDI.lookup() method to obtain a BeanManager instance.
This allows to use jersey-gf-cdi to integrate CDI and Jersey also on platforms which don't allow to bind the standard CDI location (Tomcat 6, for example).
