### PR TITLE
JERSEY-2272 Fixed HttpDigestAuthFilter MD5 algorithm token

### DIFF
--- a/core-client/src/main/java/org/glassfish/jersey/client/filter/HttpDigestAuthFilter.java
+++ b/core-client/src/main/java/org/glassfish/jersey/client/filter/HttpDigestAuthFilter.java
@@ -525,7 +525,7 @@ public class HttpDigestAuthFilter implements ClientRequestFilter, ClientResponse
         }
     }
 
-    private enum Algorithm {
+    protected enum Algorithm {
 
         UNSPECIFIED(null),
         MD5("MD5"),

--- a/core-client/src/test/java/org/glassfish/jersey/client/filter/HttpDigestAuthFilterTest.java
+++ b/core-client/src/test/java/org/glassfish/jersey/client/filter/HttpDigestAuthFilterTest.java
@@ -134,4 +134,22 @@ public class HttpDigestAuthFilterTest {
         Assert.assertEquals("foo, bar", ds.getNonce());
         Assert.assertEquals("bar", ds.getOpaque());
     }
+    
+    @Test
+    public void testParseHeaders6() throws Exception
+    {
+        HttpDigestAuthFilter f = new HttpDigestAuthFilter("foo", "bar");
+        Method method = HttpDigestAuthFilter.class.getDeclaredMethod("parseAuthHeaders", List.class);
+        method.setAccessible(true);
+        DigestScheme ds = (DigestScheme) method.invoke(f,
+                Arrays.asList(new String[]{
+                        "Digest realm=\"tada\",domain=\"/management\",nonce=\"foo, bar\",opaque=\"bar\",algorithm=MD5"
+                }));
+
+        Assert.assertNotNull(ds);
+        Assert.assertEquals("tada", ds.getRealm());
+        Assert.assertEquals("foo, bar", ds.getNonce());
+        Assert.assertEquals("bar", ds.getOpaque());
+        Assert.assertEquals(HttpDigestAuthFilter.Algorithm.MD5, ds.getAlgorithm());
+    }
 }


### PR DESCRIPTION
HttpDigestAuthFilter uses "algorithm=md5". Accoring to rfc2617 it should be "algorithm=MD5".
