### PR TITLE
JERSEY-1611 Propagate redirected URL

### DIFF
--- a/core-client/src/main/java/org/glassfish/jersey/client/ClientResponse.java
+++ b/core-client/src/main/java/org/glassfish/jersey/client/ClientResponse.java
@@ -45,6 +45,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.lang.annotation.Annotation;
+import java.net.URI;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
@@ -76,6 +77,7 @@ import com.google.common.collect.Sets;
 public class ClientResponse extends InboundMessageContext implements ClientResponseContext {
     private Response.StatusType status;
     private final ClientRequest requestContext;
+    private URI uri;
 
     /**
      * Create new Jersey client response context initialized from a JAX-RS {@link Response response}.
@@ -167,6 +169,23 @@ public class ClientResponse extends InboundMessageContext implements ClientRespo
     }
 
     /**
+     * Get the URI of the final request.
+     * <p>
+     * This value might differ from {@link #getRequestContext()#getUri()} if the
+     * client has followed redirections.
+     * 
+     * @return the absolute uri of the requested resource, following any redirections
+     * @see ClientProperties#FOLLOW_REDIRECTS
+     * @since 2.6
+     */
+    public URI getUri() {
+        if (uri == null) {
+            return getRequestContext().getUri();
+        }
+        return uri;
+    }
+    
+    /**
      * Get the associated client request context paired with this response context.
      *
      * @return associated client request context.
@@ -189,7 +208,7 @@ public class ClientResponse extends InboundMessageContext implements ClientRespo
                     return link;
                 }
 
-                return Link.fromLink(link).baseUri(requestContext.getUri()).build();
+                return Link.fromLink(link).baseUri(getUri()).build();
             }
         }));
     }
@@ -393,6 +412,19 @@ public class ClientResponse extends InboundMessageContext implements ClientRespo
     public <T> T readEntity(GenericType<T> entityType, Annotation[] annotations)
             throws ProcessingException, IllegalStateException {
         return (T) readEntity(entityType.getRawType(), entityType.getType(), annotations, requestContext.getPropertiesDelegate());
+    }
+
+    /**
+     * Set the URI of the final request.
+     * <p>
+     * This value might differ from {@link #getRequestContext()#getUri()} if the
+     * client has followed redirections.
+     * 
+     * @param uri the absolute uri of the requested resource, following any redirections
+     * @since 2.6
+     */
+    public void setUri(URI uri) {
+        this.uri = uri;
     }
 
 }

--- a/core-client/src/main/java/org/glassfish/jersey/client/HttpUrlConnector.java
+++ b/core-client/src/main/java/org/glassfish/jersey/client/HttpUrlConnector.java
@@ -46,6 +46,8 @@ import java.io.OutputStream;
 import java.lang.reflect.Field;
 import java.net.HttpURLConnection;
 import java.net.ProtocolException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.security.AccessController;
 import java.security.PrivilegedActionException;
 import java.security.PrivilegedExceptionAction;
@@ -281,7 +283,13 @@ class HttpUrlConnector implements Connector {
                 status, request);
         responseContext.headers(Maps.<String, List<String>>filterKeys(uc.getHeaderFields(), Predicates.notNull()));
         responseContext.setEntityStream(getInputStream(uc));
-
+        try {
+            // the final URL after following redirections
+            URI finalURL = uc.getURL().toURI();
+            responseContext.setUri(finalURL);
+        } catch (URISyntaxException e) {
+            throw new ProcessingException(e);
+        }
         return responseContext;
     }
 


### PR DESCRIPTION
See https://java.net/jira/browse/JERSEY-1611

This adds the getUri() method to ClientResponse which contains
the final URL after following any redirections. This will differ
from the getClientRequest().getUri() if the client has followed
any redirections.

The test verifies this by changing the getURL() in the
wrapped HttpUrlConnection.

ClientResponse.getLinks() has been updated to use the correct
base URL (getUri()) after redirection - however note that strictly
speaking (RFC2616) the Links should also be resolved according to
the Content-Location header, if present. (this is a separate bug).

In case ClientResponse.setUri() has not been set (constructed
outside of HttpUrlConnector) , getUri returns the 
requested URI from getClientRequest().getUri() (e.g. getLinks() would
behave as before).
