### PR TITLE
JERSEY-2315 JerseyTest now uses it's own getProperty method for getting ...

### DIFF
--- a/test-framework/core/src/main/java/org/glassfish/jersey/test/JerseyTest.java
+++ b/test-framework/core/src/main/java/org/glassfish/jersey/test/JerseyTest.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) 2010-2013 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010-2014 Oracle and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development

--- a/test-framework/core/src/test/java/org/glassfish/jersey/test/JerseyTestTest.java
+++ b/test-framework/core/src/test/java/org/glassfish/jersey/test/JerseyTestTest.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) 2011-2013 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011-2014 Oracle and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development


### PR DESCRIPTION
...the port number to use, which makes it possible to overriding it by calling jerseyTest.set(TestProperties.CONTAINER_PORT, N).

See https://java.net/jira/browse/JERSEY-2315
