### PR TITLE
Add Expires to toString if set, with prefered date format.

### DIFF
--- a/core-common/src/main/java/org/glassfish/jersey/message/internal/NewCookieProvider.java
+++ b/core-common/src/main/java/org/glassfish/jersey/message/internal/NewCookieProvider.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) 2010-2013 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010-2014 Oracle and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -97,7 +97,12 @@ public class NewCookieProvider implements HeaderDelegateProvider<NewCookie> {
         if (cookie.isHttpOnly()) {
             b.append(";HttpOnly");
         }
-        return b.toString();
+        if (cookie.getExpiry() != null) {
+          b.append(";Expires=");
+          b.append(HttpDateFormat.getPreferedDateFormat().format(cookie.getExpiry()));
+        }
+
+      return b.toString();
     }
 
     @Override


### PR DESCRIPTION
Some clients (IE) does not handle MaxAge this diff will set Expires to the expiry date of NewCookie if expiration date has been set.
