### PR TITLE
JERSEY-2317 Fixing tests that fail unless jersey.config.test.container.p...

### DIFF
--- a/examples/servlet3-webapp/pom.xml
+++ b/examples/servlet3-webapp/pom.xml
@@ -101,7 +101,7 @@
                     </webApp>
                     <connectors>
                         <connector implementation="org.eclipse.jetty.server.nio.SelectChannelConnector">
-                            <port>${jersey.config.test.container.port}</port>
+                            <port>9998</port>
                             <maxIdleTime>60000</maxIdleTime>
                         </connector>
                     </connectors>

--- a/test-framework/core/src/test/java/org/glassfish/jersey/test/JerseyTestTest.java
+++ b/test-framework/core/src/test/java/org/glassfish/jersey/test/JerseyTestTest.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) 2011-2013 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011-2014 Oracle and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -116,7 +116,6 @@ public class JerseyTestTest {
     @Test
     public void testCustomTestContainerFactory() {
         MyJerseyTest myJerseyTest = new MyJerseyTest();
-
         assertEquals(myJerseyTest.getTestContainerFactory().getClass(), MyTestContainerFactory.class);
     }
 }

--- a/tests/integration/jersey-2136/pom.xml
+++ b/tests/integration/jersey-2136/pom.xml
@@ -88,7 +88,7 @@
                 <artifactId>appengine-maven-plugin</artifactId>
                 <version>${gae.version}</version>
                 <configuration>
-                    <port>${jersey.config.test.container.port}</port>
+                    <port>9998</port>
                     <offline>true</offline>
                 </configuration>
                 <executions>

--- a/tests/integration/jersey-2154/pom.xml
+++ b/tests/integration/jersey-2154/pom.xml
@@ -100,6 +100,6 @@
     <properties>
         <skipTests>true</skipTests>
         <testContainerFactory>org.glassfish.jersey.test.external.ExternalTestContainerFactory</testContainerFactory>
-        <testContainerPort>8080</testContainerPort>
+        <testContainerPort>9998</testContainerPort>
     </properties>
 </project>

--- a/tests/integration/pom.xml
+++ b/tests/integration/pom.xml
@@ -138,7 +138,7 @@
                         </webApp>
                         <connectors>
                             <connector implementation="org.eclipse.jetty.server.nio.SelectChannelConnector">
-                                <port>${jersey.config.test.container.port}</port>
+                                <port>9998</port>
                                 <maxIdleTime>60000</maxIdleTime>
                             </connector>
                         </connectors>


### PR DESCRIPTION
...ort was set to a valid value. Since BuildHive sets it to an empty value, these would always fail. Setting the Maven Jetty Plugins to use the default Jersey port (9998) fixes this, although it is less flexible.
