### PR TITLE
Fix to JERSEY-2408

### DIFF
--- a/core-server/src/main/java/org/glassfish/jersey/server/model/Parameter.java
+++ b/core-server/src/main/java/org/glassfish/jersey/server/model/Parameter.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) 2010-2013 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010-2014 Oracle and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development


### PR DESCRIPTION
Added default hashCode/equals generated by eclipse to eliminate memory
leak when this Parameter object is used as a key.
Please consider getting this into 2.5.2 or netxt best choice As soon as possible.
