### PR TITLE
Gave the OAuth filter authentication priority.

### DIFF
--- a/security/oauth1-server/src/main/java/org/glassfish/jersey/server/oauth1/OAuth1ServerFilter.java
+++ b/security/oauth1-server/src/main/java/org/glassfish/jersey/server/oauth1/OAuth1ServerFilter.java
@@ -52,9 +52,12 @@ import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.container.ContainerRequestFilter;
 import javax.ws.rs.core.Configuration;
 import javax.ws.rs.core.Response;
+import javax.ws.rs.Priorities;
 
 import javax.inject.Inject;
 import javax.inject.Provider;
+
+import javax.annotation.Priority;
 
 import org.glassfish.jersey.internal.util.PropertiesHelper;
 import org.glassfish.jersey.oauth1.signature.OAuth1Parameters;
@@ -74,6 +77,7 @@ import org.glassfish.jersey.server.oauth1.internal.OAuthServerRequest;
  * @author Paul C. Bryan <pbryan@sun.com>
  * @author Martin Matula
  */
+@Priority(Priorities.AUTHENTICATION)
 class OAuth1ServerFilter implements ContainerRequestFilter {
 
     /** OAuth Server */


### PR DESCRIPTION
If you want to use the `javax.annotation.security` annotations and the `RolesAllowedDynamicFeature` with the `OAuth1ServerFeature`, the `OAuth1ServerFilter` needs to have `AUTHENTICATION` priority so that it is executed before the `RolesAllowedRequestFilter` (which has `AUTHORIZATION` priority).  This commit fixes this issue and allows the two to be used together.
