### PR TITLE
Fixed @Path annotation in 'Rules of Injection' example.

### DIFF
--- a/docs/src/main/docbook/jaxrs-resources.xml
+++ b/docs/src/main/docbook/jaxrs-resources.xml
@@ -888,7 +888,7 @@ public class ItemResource {
         <para>
             <example>
                 <title>Injection</title>
-                <programlisting language="java" linenumbering="numbered">@Path("id: \d+")
+                <programlisting language="java" linenumbering="numbered">@Path("{id:\\d+}")
 public class InjectedResource {
     // Injection onto field
     @DefaultValue("q") @QueryParam("p")


### PR DESCRIPTION
The previous code @Path("id: \d+") does not work.
