### PR TITLE
FIXED JERSEY-2484

### DIFF
--- a/containers/grizzly2-http/src/main/java/org/glassfish/jersey/grizzly2/httpserver/GrizzlyHttpServerFactory.java
+++ b/containers/grizzly2-http/src/main/java/org/glassfish/jersey/grizzly2/httpserver/GrizzlyHttpServerFactory.java
@@ -240,6 +240,7 @@ public final class GrizzlyHttpServerFactory {
                 // Start the server.
                 server.start();
             } catch (IOException ex) {
+                server.shutdownNow();
                 throw new ProcessingException(LocalizationMessages.FAILED_TO_START_SERVER(ex.getMessage()), ex);
             }
         }


### PR DESCRIPTION
- GrizzlyHttpServerFactory must call HttpServer.shutdownNow() when exceptions happened.
