### PR TITLE
Split POM license declaration in two.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -160,8 +160,13 @@
 
     <licenses>
         <license>
-            <name>CDDL+GPL License</name>
-            <url>http://glassfish.java.net/public/CDDL+GPL_1_1.html</url>
+            <name>CDDL 1.1</name>
+            <url>https://jersey.java.net/license.html#cddl</url>
+            <distribution>repo</distribution>
+        </license>
+        <license>
+            <name>GPLv2 with classpath exception</name>
+            <url>https://jersey.java.net/license.html#gpl</url>
             <distribution>repo</distribution>
         </license>
     </licenses>


### PR DESCRIPTION
The Maven POM allows one to specify multiple licenses. This is useful for dual (or triple) licensed projects such as Jersey. However, Jersey currently:
- ...declares its licenses in a single `<license>` element, using the plus sign.
- ...doesn't declare the version of the licenses used.

Both these things are inconvenient for users of the [`license-maven-plugin`](http://mojo.codehaus.org/license-maven-plugin/), as it doesn't allow one to "[_merge_](http://mojo.codehaus.org/license-maven-plugin/add-third-party-mojo.html#licenseMerges)" the licenses with other uses of the _CDDL 1.1_ and/or _GPLv2 with classpath exception_.

The change proposed by this pull request distributes the license declaration over two `<license>` elements. (NB: If you accept this patch, note that the HK2 POMs should similarly be updated.)
