### PR TITLE
Add ImmutableMultivaluedMap.toString() for nice debugging

### DIFF
--- a/core-common/src/main/java/org/glassfish/jersey/internal/util/collection/ImmutableMultivaluedMap.java
+++ b/core-common/src/main/java/org/glassfish/jersey/internal/util/collection/ImmutableMultivaluedMap.java
@@ -172,4 +172,9 @@ public class ImmutableMultivaluedMap<K, V> implements MultivaluedMap<K, V> {
     public Set<Entry<K, List<V>>> entrySet() {
         return Collections.unmodifiableSet(delegate.entrySet());
     }
+	
+    @Override
+    public String toString() {
+        return delegate.toString();
+    }
 }


### PR DESCRIPTION
When writing a service that needs dynamic query parameters, it's nice to be able to log them out. Unfortunately the parameters object returned by `UriInfo.getQueryParameters()` is an `ImmutableMultivaluedMap` which doesn't have a `toString()` method.

This patch adds that so that a developer can log out the parameters easily.

Edit: Filed [JERSEY-2563](https://java.net/jira/browse/JERSEY-2563)
