### PR TITLE
+ fix issue #2532

### DIFF
--- a/containers/grizzly2-http/src/main/java/org/glassfish/jersey/grizzly2/httpserver/GrizzlyHttpServerFactory.java
+++ b/containers/grizzly2-http/src/main/java/org/glassfish/jersey/grizzly2/httpserver/GrizzlyHttpServerFactory.java
@@ -49,6 +49,7 @@ import org.glassfish.jersey.server.ApplicationHandler;
 import org.glassfish.jersey.server.ResourceConfig;
 
 import org.glassfish.grizzly.http.server.HttpHandler;
+import org.glassfish.grizzly.http.server.HttpHandlerRegistration;
 import org.glassfish.grizzly.http.server.HttpServer;
 import org.glassfish.grizzly.http.server.NetworkListener;
 import org.glassfish.grizzly.http.server.ServerConfiguration;
@@ -230,7 +231,15 @@ public final class GrizzlyHttpServerFactory {
         // Map the path to the processor.
         final ServerConfiguration config = server.getServerConfiguration();
         if (handler != null) {
-            config.addHttpHandler(handler, uri.getPath());
+            final String path = uri.getPath().replaceAll("/{2,}", "/");
+            
+            config.addHttpHandler(handler,
+                    HttpHandlerRegistration.bulder()
+                    .contextPath(path.endsWith("/")
+                            ? path.substring(0, path.length() - 1)
+                            : path)
+                    .build()
+            );
         }
 
         config.setPassTraceRequest(true);


### PR DESCRIPTION
https://java.net/jira/browse/JERSEY-2532
"SE deployment with Grizzly container does not honour the full the context path"
