### PR TITLE
Switching to most recent version of html4j - version 1.0

### DIFF
--- a/incubator/html-json/pom.xml
+++ b/incubator/html-json/pom.xml
@@ -62,7 +62,7 @@
     </description>
     
     <properties>
-        <net.java.html.version>0.8.3</net.java.html.version>
+        <net.java.html.version>1.0</net.java.html.version>
     </properties>
 
     <repositories>


### PR DESCRIPTION
NetBeans released version 1.0 of html4j: http://bits.netbeans.org/html4j/1.0/ 
It is desirable for down-stream projects to adopt it.
