### PR TITLE
Upgrade to hk2 2.3.0 final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1463,7 +1463,7 @@
         <grizzly.client.version>1.8</grizzly.client.version>
         <grizzly2.version>2.3.16</grizzly2.version>
         <hamcrest.version>1.3</hamcrest.version>
-        <hk2.version>2.3.0-b10</hk2.version>
+        <hk2.version>2.3.0</hk2.version>
         <asm.version>5.0.2</asm.version>
         <httpclient.version>4.3.1</httpclient.version>
         <jackson.version>2.3.2</jackson.version>


### PR DESCRIPTION
This patch upgrades hk2 dependency from 2.3.0 beta 10 to final release.
