### PR TITLE
Cleared relative path to bom module parent pom

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -48,6 +48,7 @@
         <groupId>net.java</groupId>
         <artifactId>jvnet-parent</artifactId>
         <version>4</version>
+        <relativePath />
     </parent>
 
     <groupId>org.glassfish.jersey</groupId>


### PR DESCRIPTION
Before this fix Maven builds would report a warning on inconsistency between actual parent pom and pom at parent relative path for Jersey BOM module (Maven default parent.relativePath is ../pom.xml) .

This patch fixes the issue by clearing the parent.relativePath property.

Issue: JERSEY-2686
