### PR TITLE
Do not swallow exceptions in finally

### DIFF
--- a/core-client/src/main/java/org/glassfish/jersey/client/ClientRequest.java
+++ b/core-client/src/main/java/org/glassfish/jersey/client/ClientRequest.java
@@ -538,13 +538,13 @@ public class ClientRequest extends OutboundMessageContext implements ClientReque
                 if (entityStream != null) {
                     try {
                         entityStream.close();
-                    } catch (final IOException ex) {
+                    } catch (final Throwable ex) {
                         LOGGER.log(Level.FINE, LocalizationMessages.ERROR_CLOSING_OUTPUT_STREAM(), ex);
                     }
                 }
                 try {
                     commitStream();
-                } catch (final IOException e) {
+                } catch (final Throwable e) {
                     LOGGER.log(Level.SEVERE, LocalizationMessages.ERROR_COMMITTING_OUTPUT_STREAM(), e);
                 }
             }


### PR DESCRIPTION
This leads to situations where we cannot connect, then try to commit the stream and throw an already connected exception, swallowing the original "cannot connect" exception.
