### PR TITLE
make sure that @Produces @Consumes works

### DIFF
--- a/ext/proxy-client/src/main/java/org/glassfish/jersey/client/proxy/WebResourceFactory.java
+++ b/ext/proxy-client/src/main/java/org/glassfish/jersey/client/proxy/WebResourceFactory.java
@@ -274,12 +274,22 @@ public final class WebResourceFactory implements InvocationHandler {
             return WebResourceFactory.newResource(responseType, newTarget, true, headers, cookies, form);
         }
 
-        // accepted media types
-        Produces produces = method.getAnnotation(Produces.class);
-        if (produces == null) {
-            produces = proxyIfc.getAnnotation(Produces.class);
+		// accepted media types
+		Produces produces = method.getAnnotation(Produces.class);
+		if (produces == null) {
+		    produces = proxyIfc.getAnnotation(Produces.class);
+		}
+		
+        Invocation.Builder builder;
+		final String[] accepts = produces == null ? null : produces.value();
+        if (accepts != null) {
+            builder = newTarget.request(accepts);
+        } else {
+            builder = newTarget.request();
         }
-        final String[] accepts = produces == null ? null : produces.value();
+
+        // apply header params and cookies
+        builder.headers(headers);
 
         // determine content type
         String contentType = null;
@@ -293,16 +303,6 @@ public final class WebResourceFactory implements InvocationHandler {
                 contentType = consumes.value()[0];
             }
         }
-
-        Invocation.Builder builder;
-        if (accepts != null) {
-            builder = newTarget.request(accepts);
-        } else {
-            builder = newTarget.request();
-        }
-
-        // apply header params and cookies
-        builder.headers(headers);
 
         for (final Cookie c : cookies) {
             builder = builder.cookie(c);


### PR DESCRIPTION
builder.headers(headers) overwrites/deletes all header values set before. Thus @Consumes/@Produces MediaTypes are not taken into account
