### PR TITLE
Update artifact for incubator/html-json module, fixes JERSEY-2716

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,5 @@ nb-configuration.xml
 
 # Maven plugins noise
 dependency-reduced-pom.xml
+pom.xml.versionsBackup
+

--- a/incubator/html-json/pom.xml
+++ b/incubator/html-json/pom.xml
@@ -84,9 +84,9 @@
             <version>${net.java.html.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.netbeans.api</groupId>
+            <groupId>org.codeartisans.thirdparties.swing</groupId>
             <artifactId>org-openide-util-lookup</artifactId>
-            <version>RELEASE80</version>
+            <version>8.3.1</version>
             <scope>provided</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
Hi,

This pull request is to fix issue described in [JERSEY-2716](https://java.net/jira/browse/JERSEY-2716). 

The problem is the following. When I build Jersey, Maven claims that the following dependency is not available in Maven Central (which is true):

``` plain
Could not find artifact org.netbeans.api:org-openide-util-lookup:jar:RELEASE80
```

Therefore, I updated it to point the following one:

``` xml
<dependency>
  <groupId>org.codeartisans.thirdparties.swing</groupId>
  <artifactId>org-openide-util-lookup</artifactId>
  <version>8.3.1</version>
  <scope>provided</scope>
</dependency>
```

My OCA has been already submitted and accepted.
