### PR TITLE
#3593: WebResourceFactory issue when @Context after entity in signature

### DIFF
--- a/ext/proxy-client/src/main/java/org/glassfish/jersey/client/proxy/WebResourceFactory.java
+++ b/ext/proxy-client/src/main/java/org/glassfish/jersey/client/proxy/WebResourceFactory.java
@@ -70,6 +70,7 @@ import javax.ws.rs.QueryParam;
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.client.Invocation;
 import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.Context;
 import javax.ws.rs.core.Cookie;
 import javax.ws.rs.core.Form;
 import javax.ws.rs.core.GenericEntity;
@@ -221,8 +222,10 @@ public final class WebResourceFactory implements InvocationHandler {
             Annotation ann;
             Object value = args[i];
             if (!hasAnyParamAnnotation(anns)) {
-                entityType = method.getGenericParameterTypes()[i];
-                entity = value;
+                if (!anns.containsKey(Context.class)){
+                    entityType = method.getGenericParameterTypes()[i];
+                    entity = value;
+                }
             } else {
                 if (value == null && (ann = anns.get(DefaultValue.class)) != null) {
                     value = ((DefaultValue) ann).value();

--- a/ext/proxy-client/src/test/java/org/glassfish/jersey/client/proxy/MyResource.java
+++ b/ext/proxy-client/src/test/java/org/glassfish/jersey/client/proxy/MyResource.java
@@ -42,7 +42,7 @@ package org.glassfish.jersey.client.proxy;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
-
+import javax.ws.rs.core.SecurityContext;
 import java.util.List;
 import java.util.Set;
 import java.util.SortedSet;
@@ -185,5 +185,10 @@ public class MyResource implements MyResourceIfc {
     @Override
     public String putIt(MyBean dummyBean) {
         return headers.getHeaderString(HttpHeaders.CONTENT_TYPE);
+    }
+
+    @Override
+    public MyBean postEntityWithContextParam(MyBean entity, SecurityContext securityContext) {
+        return entity;
     }
 }

--- a/ext/proxy-client/src/test/java/org/glassfish/jersey/client/proxy/MyResourceIfc.java
+++ b/ext/proxy-client/src/test/java/org/glassfish/jersey/client/proxy/MyResourceIfc.java
@@ -58,6 +58,7 @@ import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.SecurityContext;
 
 @Path("myresource")
 public interface MyResourceIfc {
@@ -194,4 +195,10 @@ public interface MyResourceIfc {
     @PUT
     @Consumes({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
     String putIt(MyBean dummyBean);
+
+    @Path("postEntityWithContextParam")
+    @POST
+    @Consumes({MediaType.APPLICATION_XML})
+    @Produces({MediaType.APPLICATION_XML})
+    MyBean postEntityWithContextParam(@Valid MyBean entity, @Context SecurityContext securityContext);
 }

--- a/ext/proxy-client/src/test/java/org/glassfish/jersey/client/proxy/WebResourceFactoryTest.java
+++ b/ext/proxy-client/src/test/java/org/glassfish/jersey/client/proxy/WebResourceFactoryTest.java
@@ -340,6 +340,16 @@ public class WebResourceFactoryTest extends JerseyTest {
     }
 
     @Test
+    public void testPostEntityWithContextParam(){
+        MyBean entity = new MyBean();
+        entity.name = "vbo";
+
+        MyBean response = resource.postEntityWithContextParam(entity, null);
+
+        assertEquals("vbo", response.name);
+    }
+
+    @Test
     public void testToString() throws Exception {
         final String actual = resource.toString();
         final String expected = target().path("myresource").toString();


### PR DESCRIPTION
Fixed JERSEY#3593. `@Context` annotated parameters are now ignored in `WebResourceFactory` such that entity is not lost anymore.
Test added.
OCA already sent. 