### PR TITLE
JerseyUriBuilder: allow template parameter regexes to contain braces

### DIFF
--- a/core-common/src/main/java/org/glassfish/jersey/uri/UriComponent.java
+++ b/core-common/src/main/java/org/glassfish/jersey/uri/UriComponent.java
@@ -285,7 +285,7 @@ public class UriComponent {
 
     private static String _encode(final String s, final Type t, final boolean template, final boolean contextualEncode) {
         final boolean[] table = ENCODING_TABLES[t.ordinal()];
-        boolean insideTemplateParam = false;
+        int templateParamDepth = 0;
 
         StringBuilder sb = null;
         for (int offset = 0, codePoint; offset < s.length(); offset += Character.charCount(codePoint)) {
@@ -299,12 +299,12 @@ public class UriComponent {
                 if (template) {
                     boolean leavingTemplateParam = false;
                     if (codePoint == '{') {
-                        insideTemplateParam = true;
+                        ++templateParamDepth;
                     } else if (codePoint == '}') {
-                        insideTemplateParam = false;
+                        --templateParamDepth;
                         leavingTemplateParam = true;
                     }
-                    if (insideTemplateParam || leavingTemplateParam) {
+                    if (templateParamDepth > 0 || leavingTemplateParam) {
                         if (sb != null) {
                             sb.append(Character.toChars(codePoint));
                         }

--- a/tests/e2e-core-common/src/test/java/org/glassfish/jersey/tests/e2e/common/uri/internal/JerseyUriBuilderTest.java
+++ b/tests/e2e-core-common/src/test/java/org/glassfish/jersey/tests/e2e/common/uri/internal/JerseyUriBuilderTest.java
@@ -49,8 +49,10 @@ import java.net.URL;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 
 import javax.ws.rs.GET;
+import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.core.MultivaluedMap;
@@ -1068,6 +1070,10 @@ public class JerseyUriBuilderTest {
         public Object locator() {
             return null;
         }
+
+        @PUT
+        @Path("complex/{id3: \\p{XDigit}{8}(?:-\\p{XDigit}{4}){3}-\\p{XDigit}{12}}")
+        public void put() {}
     }
 
     @Test
@@ -1082,6 +1088,11 @@ public class JerseyUriBuilderTest {
         final Method locator = ResourceWithTemplateRegex.class.getMethod("locator");
         ub = UriBuilder.fromUri("http://localhost:8080/base").path(get).path(locator).build("foo", "bar");
         Assert.assertEquals(URI.create("http://localhost:8080/base/method/foo/locator/bar"), ub);
+
+        final Method put = ResourceWithTemplateRegex.class.getMethod("put");
+        final UUID uuid = UUID.randomUUID();
+        ub = UriBuilder.fromUri("http://localhost:8080/base").path(put).build(uuid);
+        Assert.assertEquals(URI.create("http://localhost:8080/base/complex/" + uuid), ub);
     }
 
     interface GenericInterface<T, U> {


### PR DESCRIPTION
The [template parameter syntax](https://javaee.github.io/javaee-spec/javadocs/javax/ws/rs/Path.html#value--) allows the regex to have one level of braces, as long as they are evenly matched, arbitrarily many times.

However, `JerseyUriBuilder` does not currently handle this correctly: all the non-URL-safe characters (such as backslashes) after the first closing brace gets encoded, making the regex unable to be compiled successfully.